### PR TITLE
add 2 bytes write feature

### DIFF
--- a/SmcDumpKey.c
+++ b/SmcDumpKey.c
@@ -221,5 +221,14 @@ main(int argc, char **argv)
 		fprintf(stderr,"\nwrite_smc get_key_data error\n\n");
   }
 
+  if (argc == 4) {
+    uint8_t val[2];
+    val[0] = atoi(argv[2]);
+    val[1] = atoi(argv[3]);
+    printf("target value: %02x%02x\n",val[0],val[1]);
+    if (write_smc(APPLESMC_WRITE_CMD,(uint8_t*)argv[1],val,2))
+      fprintf(stderr,"\nwrite_smc get_key_data error\n\n");
+  }
+
   return 0;
 }


### PR DESCRIPTION
I wanted to adjust brightness and found writing to `MVBO` will change brightness.
It requires 2 bytes write, so I changed SmcDumpKey to accept the 3rd argument for 2 bytes write.

usage:
`./SmcDumpKey MVBO 1 2`
will write `0x0102` to `MVBO`

I'm running following script as root on boot.

```
#!/bin/bash
/usr/local/sbin/SmcDumpKey MVHR 1
sleep 3
/usr/local/sbin/SmcDumpKey MVBO 64 0
sleep 3
/usr/local/sbin/SmcDumpKey MVMR 2
```

I hope it helps somebody.