### PR TITLE
iMac powerbutton support

### DIFF
--- a/acpi/README.md
+++ b/acpi/README.md
@@ -1,0 +1,30 @@
+# Use iMac powerbutton to toggle TDM
+
+Since the powerbutton is the only physical button on the iMac, the following instructions allow using the powerbutton to toggle TDM (and to switch off the iMac as well, of course). No more keyboard/mouse are needed and the iMac can be used as an external monitor.
+
+How it works:
+- After boot, iMac starts in TDM mode
+- One press of the power button toggles TDM mode
+- Two presses of the power button (within 1 second) switches off the iMac
+
+# How to use
+
+Install by following the instructions in the main README file
+
+Upon startup, switch TDM on:
+```
+cp rc.local /etc/rc.local
+```
+
+Add acpi powerbutton event and script to handle event:
+```
+cp powerbutton /etc/acpi/events
+cp powerbutton.sh /etc/acpi
+```
+
+Restart acpid
+```
+systemctl restart acpid
+```
+
+_Note_: This was tested on a end-2009 27" iMac running Ubuntu 20.10

--- a/acpi/powerbutton
+++ b/acpi/powerbutton
@@ -1,0 +1,2 @@
+event=button/power PBTN
+action=/etc/acpi/powerbutton.sh

--- a/acpi/powerbutton.sh
+++ b/acpi/powerbutton.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+pushd $(dirname "${BASH_SOURCE[0]}")
+
+FILE=powerbutton_pressed
+NOW=$(date +%s)
+
+if [[ -f "$FILE" ]]; then
+  # Read timestamp of previous powerbutton press from file
+  echo "File exists"
+  typeset -i PREV=$(cat $FILE)
+  echo Compare $NOW and $PREV
+
+  # if two powerbutton presses were <1 seconds apart -> shutdown
+  if [[ $(($NOW-$PREV)) -lt 2 ]]; then
+    # Shutdown
+    echo "Powerbutton pressed twice in a row: Shutting down"
+    shutdown now
+  else
+    echo "Toggle TDM"
+    /home/freek/smc_util/tdm_toggle.sh &
+  fi
+else
+  echo "Toggle TDM"
+  /home/freek/smc_util/tdm_toggle.sh &
+fi
+
+echo $NOW > $FILE
+
+popd

--- a/acpi/rc.local
+++ b/acpi/rc.local
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Start Target Display Mode such that the pc is used as external monitor right away
+# Note: The Power button toggles TDM (see /etc/acpi/events)
+pushd /home/freek/smc_util
+./tdm_on.sh
+popd

--- a/tdm_off.sh
+++ b/tdm_off.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+rm -f tdm_started
 ./SmcDumpKey MVHR 0
 sleep 1
 ./SmcDumpKey MVMR 2

--- a/tdm_on.sh
+++ b/tdm_on.sh
@@ -4,3 +4,4 @@ sleep 1
 ./SmcDumpKey MVMR 2
 sleep 2
 DISPLAY=:0.0 xrandr --output eDP --off
+touch tdm_started

--- a/tdm_toggle.sh
+++ b/tdm_toggle.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+pushd $(dirname "${BASH_SOURCE[0]}")
+
+if [[ -f "tdm_started" ]]; then
+  echo "Switching off TDM"
+  source tdm_off.sh
+else
+  echo "Switch on TDM"  
+  source tdm_on.sh
+fi
+
+popd


### PR DESCRIPTION
Use iMac as external monitor by using the powerbutton to toggle TDM mode.